### PR TITLE
feat(proxy): Integrate dynamic proxy fetching from API

### DIFF
--- a/core/proxy_manager.py
+++ b/core/proxy_manager.py
@@ -1,14 +1,54 @@
-import aiohttp
-import asyncio
+import httpx
 import random
 
-class ProxyManager:
-    def __init__(self):
-        self.proxies = [
-            "104.248.90.211:3128",
-            "103.151.246.38:8080",
-            "185.132.133.65:80"
-        ]
+# آدرس API برای دریافت پراکسی از ProxyScrape.
+# !!! توجه: این آدرس یک نمونه است. لطفاً آن را با آدرس API مخصوص خودتان از داشبورد ProxyScrape جایگزین کنید.
+# شما می‌توانید پارامترهایی مانند کشور، نوع پراکسی و... را در این آدرس تنظیم کنید.
+PROXY_API_URL = "https://api.proxyscrape.com/v2/?request=getproxies&protocol=http&timeout=10000&country=all&ssl=all&anonymity=elite"
 
-    async def get_proxy(self):
-        return {"server": f"http://{random.choice(self.proxies)}"}
+# لیست موقت برای نگهداری پراکسی‌ها در حافظه تا از درخواست‌های تکراری جلوگیری شود.
+_proxy_cache = []
+_proxy_index = 0
+
+async def fetch_proxies():
+    """
+    پراکسی‌ها را از API دریافت کرده و در حافظه ذخیره می‌کند.
+    """
+    global _proxy_cache
+    print("⏳ در حال دریافت لیست پراکسی‌های جدید از API...")
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(PROXY_API_URL, timeout=20)
+            # در صورت بروز خطای HTTP، آن را نمایش داده و لیست خالی برمی‌گرداند.
+            response.raise_for_status()
+
+        proxies = response.text.strip().split('\r\n')
+        if not proxies or not proxies[0]:
+            print("⚠️ هشدار: API پراکسی لیست خالی برگرداند.")
+            _proxy_cache = []
+            return
+
+        # پراکسی‌ها را با فرمت صحیح "http://ip:port" آماده می‌کنیم.
+        _proxy_cache = [f"http://{p.strip()}" for p in proxies if p.strip()]
+        random.shuffle(_proxy_cache) # لیست پراکسی‌ها را به هم می‌ریزیم تا توزیع تصادفی باشد.
+        print(f"✅ تعداد {len(_proxy_cache)} پراکسی جدید با موفقیت دریافت و ذخیره شد.")
+
+    except httpx.RequestError as e:
+        print(f"❌ خطا در هنگام درخواست به API پراکسی: {e}")
+        _proxy_cache = []
+    except Exception as e:
+        print(f"❌ خطای نامشخص هنگام دریافت پراکسی‌ها: {e}")
+        _proxy_cache = []
+
+def get_next_proxy():
+    """
+    یک پراکسی از لیست ذخیره شده برمی‌گرداند و به صورت چرخشی بین آن‌ها حرکت می‌کند.
+    """
+    global _proxy_index
+    if not _proxy_cache:
+        return None
+
+    # انتخاب پراکسی به روش نوبتی (Round-robin)
+    proxy = _proxy_cache[_proxy_index]
+    _proxy_index = (_proxy_index + 1) % len(_proxy_cache)
+    return proxy

--- a/core/task_executor.py
+++ b/core/task_executor.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 from core.browser_manager import BrowserManager
+from core.proxy_manager import get_next_proxy
 
 # --- کلاس اجرا کننده تسک ---
 # این کلاس وظیفه مدیریت و اجرای تسک‌های اصلی هر ایجنت را بر عهده دارد.
@@ -35,8 +36,11 @@ class TaskExecutor:
             print(f"\n--- شروع پردازش لینک {i+1} از {len(links)} ---")
             print(f"🔗 ایجنت {self.agent_id}: در حال پردازش URL: {url}")
 
-            # برای هر لینک یک مرورگر جدید باز می‌کنیم تا از تداخل و مشکلات حافظه جلوگیری شود.
-            bm = BrowserManager(self.agent_id)
+            # یک پراکسی از مدیر پراکسی دریافت می‌کنیم.
+            current_proxy = get_next_proxy()
+
+            # برای هر لینک یک مرورگر جدید با پراکسی مشخص باز می‌کنیم.
+            bm = BrowserManager(self.agent_id, proxy=current_proxy)
             try:
                 # اجرای فرآیند اصلی برای یک لینک
                 await self._process_single_link(bm, url)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import asyncio
 import argparse
 import os
 from core.task_executor import TaskExecutor
+from core.proxy_manager import fetch_proxies
 
 # --- نقطه شروع اصلی برنامه (Entrypoint) ---
 async def main():
@@ -9,9 +10,11 @@ async def main():
     این تابع اصلی برنامه است که هنگام اجرای اسکریپت فراخوانی می‌شود.
     وظیفه آن، خواندن آرگومان‌های ورودی (ID ایجنت) و شروع به کار TaskExecutor است.
     """
+    # در ابتدای کار، لیست پراکسی‌ها را از API دریافت می‌کنیم.
+    await fetch_proxies()
+
     # یک پارسر برای خواندن آرگومان‌های خط فرمان (command-line) ایجاد می‌کنیم.
     parser = argparse.ArgumentParser(description="ربات پردازشگر لینک‌ها")
-
     # آرگومان agent-id-- را تعریف می‌کنیم. این آرگومان مشخص می‌کند که کدام ایجنت باید اجرا شود.
     # مقدار پیش‌فرض آن از متغیر محیطی AGENT_ID خوانده می‌شود و اگر آن هم وجود نداشت، ۱ خواهد بود.
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ playwright==1.45.0
 aiohttp==3.9.1
 fake-useragent==1.5.1
 python-dotenv==1.0.0
+httpx==0.27.0


### PR DESCRIPTION
This commit replaces the previous hardcoded proxy system with a dynamic and robust solution that fetches proxies from the ProxyScrape API.

Key changes:
- A new `core/proxy_manager.py` module has been created. It handles fetching proxies from a configurable API endpoint, caching them, and distributing them in a round-robin fashion.
- The `httpx` library has been added to `requirements.txt` for making asynchronous HTTP requests.
- The application's entrypoint (`main.py`) now triggers the proxy fetching process on startup.
- The `TaskExecutor` has been updated to request a new proxy for each task and pass it to the `BrowserManager`.

This new system makes the bot significantly more resilient to IP bans and improves its overall success rate by using a rotating list of fresh proxies.