### PR TITLE
feat(proxy): Add proxy validation before use

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import asyncio
 import argparse
 import os
 from core.task_executor import TaskExecutor
-from core.proxy_manager import fetch_proxies
+from core.proxy_manager import fetch_and_validate_proxies
 
 # --- نقطه شروع اصلی برنامه (Entrypoint) ---
 async def main():
@@ -10,8 +10,8 @@ async def main():
     این تابع اصلی برنامه است که هنگام اجرای اسکریپت فراخوانی می‌شود.
     وظیفه آن، خواندن آرگومان‌های ورودی (ID ایجنت) و شروع به کار TaskExecutor است.
     """
-    # در ابتدای کار، لیست پراکسی‌ها را از API دریافت می‌کنیم.
-    await fetch_proxies()
+    # در ابتدای کار، لیست پراکسی‌ها را از API دریافت و آن‌ها را تست می‌کنیم.
+    await fetch_and_validate_proxies()
 
     # یک پارسر برای خواندن آرگومان‌های خط فرمان (command-line) ایجاد می‌کنیم.
     parser = argparse.ArgumentParser(description="ربات پردازشگر لینک‌ها")


### PR DESCRIPTION
This commit implements a proactive proxy validation system to ensure only healthy proxies are used by the bot, preventing network errors and increasing stability. This approach was adopted based on your feedback and is superior to a reactive retry mechanism.

Key changes:
- The `core/proxy_manager.py` module has been significantly refactored.
- A new `_validate_proxy` function tests each proxy's connectivity by making a HEAD request to the target domain (`2ad.ir`).
- The main `fetch_and_validate_proxies` function now orchestrates fetching the raw proxy list and then running the validation for all of them concurrently using `asyncio.gather`.
- Only proxies that pass the validation check are added to the active proxy cache.

This prevents the bot from attempting to use dead or faulty proxies, directly addressing the `net::ERR_TUNNEL_CONNECTION_FAILED` errors and leading to a more efficient and reliable automation process.