### PR TITLE
fix(build): Use npm install instead of npm ci in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,10 @@ RUN apt-get update && apt-get install -y \
 # Copy package.json and package-lock.json (if available)
 COPY package*.json ./
 
-# Install app dependencies
-# The `npm ci` command is generally recommended for CI/CD environments as it's faster and stricter than `npm install`.
-RUN npm ci
+# Install app dependencies.
+# We use `npm install` here because it generates a `package-lock.json` if one doesn't exist.
+# `npm ci` would fail in this case.
+RUN npm install
 
 # Bundle app source
 COPY . .


### PR DESCRIPTION
This commit fixes a critical build failure caused by an incorrect npm command in the Dockerfile.

The build process was failing with an `EUSAGE` error because `npm ci` was used without an existing `package-lock.json`. The `npm ci` command is a strict, production-focused command that requires a lockfile to exist beforehand. For an initial project setup, `npm install` is the correct command, as it installs dependencies based on `package.json` and generates the `package-lock.json` file.

This fix replaces `RUN npm ci` with `RUN npm install` in the `Dockerfile`. This ensures that the dependencies are installed correctly during the initial build and that a lockfile is created for subsequent, consistent builds. This resolves the build failure and allows the application environment to be set up correctly.