### PR TITLE
fix(build): Optimize for memory by using puppeteer-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM node:18-slim
 WORKDIR /app
 
 # Puppeteer requires some specific dependencies to run in a Debian environment.
-# This command installs them.
+# This command installs them, including the Chromium browser itself.
 RUN apt-get update && apt-get install -y \
+    chromium-browser \
     ca-certificates \
     fonts-liberation \
     libappindicator3-1 \

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer-core');
 const fs = require('fs/promises');
 const path = require('path');
 const UserAgent = require('user-agents');
@@ -41,6 +41,7 @@ class BrowserManager {
             }
 
             this.browser = await puppeteer.launch({
+                executablePath: '/usr/bin/chromium-browser',
                 headless: true,
                 args: args,
                 // غیرفعال کردن برخی ویژگی‌های اتوماسیون که توسط سایت‌ها قابل شناسایی است

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "axios": "^1.7.2",
     "jimp": "^0.22.12",
-    "puppeteer": "^22.12.1",
+    "puppeteer-core": "^22.12.1",
     "tesseract.js": "^5.1.0",
     "user-agents": "^1.1.255"
   }


### PR DESCRIPTION
This commit resolves a critical "Out of memory" error that occurred during the build process on the deployment platform. The error was caused by the large size of the `puppeteer` package, which downloads a full version of Chromium during `npm install`.

The following changes have been made to optimize memory usage:
1.  **Dependency Change:** The `puppeteer` package in `package.json` has been replaced with the lightweight `puppeteer-core` package. This package contains only the API and does not bundle the browser.
2.  **Dockerfile Update:** The `chromium-browser` package has been added to the `apt-get install` command in the `Dockerfile`. This ensures that a system-level version of Chromium is available in the container.
3.  **Configuration Update:** The `puppeteer.launch()` call in `main.js` has been updated to include the `executablePath: '/usr/bin/chromium-browser'` option, instructing `puppeteer-core` to use the browser installed via `apt-get` instead of downloading its own.

This standard optimization technique significantly reduces the memory footprint during the dependency installation phase, fixing the build failure without compromising any application functionality.