### PR TITLE
feat: Fetch proxies directly from JSON file

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "axios": "^1.7.2",
     "jimp": "^0.22.12",
-    "proxifly": "^2.0.2",
     "puppeteer": "^22.12.1",
     "tesseract.js": "^5.1.0",
     "user-agents": "^1.1.255"


### PR DESCRIPTION
This commit refactors the proxy manager to fetch proxies directly from the provider's JSON data file instead of using an API or a raw text file.

This approach is more stable and robust, as it avoids potential API call failures and removes the need for any client-side validation, which was causing the application to crash.

The implementation now:
- Uses axios to get the proxy list from a static JSON URL.
- Parses the JSON and extracts the full proxy strings.
- Removes the unused `proxifly` dependency from `package.json`.